### PR TITLE
feat: add TypeScript declarations

### DIFF
--- a/import-module-string.d.ts
+++ b/import-module-string.d.ts
@@ -1,0 +1,33 @@
+import type { Options, Program } from "acorn";
+import type { ModuleInfo } from "./src/resolve.js";
+
+export { parseCode } from "./src/parse-code.js";
+export { walkCode } from "./src/walk-code.js";
+export { getTarget, getTargetDataUri } from "./src/url.js";
+export { getModuleInfo } from "./src/resolve.js";
+
+export interface GetCodeOptions {
+  data?: Record<string, any>;
+  filePath?: string;
+  implicitExports?: boolean;
+  addRequire?: boolean;
+  resolveImportContent?: (
+    moduleInfo: { path: string; mode: ModuleInfo["mode"]; resolved?: string }
+  ) => string | Promise<string | undefined> | undefined;
+  serializeData?: (data: Record<string, any>) => string | Promise<string>;
+  ast?: Program;
+  acornOptions?: Options;
+  compileAsFunction?: boolean;
+}
+
+export function resolveModule(ref: string): string;
+
+export function getCode(
+  codeStr: string,
+  options?: GetCodeOptions
+): Promise<string>;
+
+export function importFromString(
+  codeStr: string,
+  options?: GetCodeOptions
+): Promise<Record<string, any>>;

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
     "acorn": "^8.15.0",
     "acorn-walk": "^8.3.4",
     "esm-import-transformer": "^3.0.5"
-  }
+  },
+  "types": "import-module-string.d.ts"
 }

--- a/src/parse-code.d.ts
+++ b/src/parse-code.d.ts
@@ -1,0 +1,3 @@
+import type { Options, Program } from "acorn";
+
+export function parseCode(code: string, parseOptions?: Options): Program;

--- a/src/preprocess-imports.d.ts
+++ b/src/preprocess-imports.d.ts
@@ -1,0 +1,14 @@
+import type { Program } from "acorn";
+import type { ModuleInfo } from "./resolve.js";
+
+export interface PreprocessOptions {
+  resolved: Array<ModuleInfo>;
+  ast: Program;
+  used: Set<string>;
+  compileAsFunction?: boolean;
+}
+
+export function preprocess(
+  codeStr: string,
+  options: PreprocessOptions
+): Promise<string | undefined>;

--- a/src/resolve.d.ts
+++ b/src/resolve.d.ts
@@ -1,0 +1,15 @@
+export type ModuleReferenceMode = "data" | "absolute" | "relative" | "bare";
+
+export interface ModuleInfo {
+  name: string;
+  mode: ModuleReferenceMode;
+  original: {
+    path: string;
+    mode: ModuleReferenceMode;
+  };
+  path: string;
+  isMetaResolved: boolean;
+  target?: string | Blob;
+}
+
+export function getModuleInfo(name: string, root?: string): ModuleInfo;

--- a/src/stringify-data.d.ts
+++ b/src/stringify-data.d.ts
@@ -1,0 +1,1 @@
+export function stringifyData(data?: Record<string, any>): string;

--- a/src/supports.d.ts
+++ b/src/supports.d.ts
@@ -1,0 +1,1 @@
+export function importFromBlob(): boolean | Promise<boolean>;

--- a/src/url.d.ts
+++ b/src/url.d.ts
@@ -1,0 +1,2 @@
+export function getTarget(codeStr: string): Promise<Blob | string>;
+export function getTargetDataUri(codeStr: string): string;

--- a/src/walk-code.d.ts
+++ b/src/walk-code.d.ts
@@ -1,0 +1,17 @@
+import type { Program } from "acorn";
+
+export interface WalkCodeFeatures {
+  export: boolean;
+  require: boolean;
+  importMetaUrl: boolean;
+}
+
+export interface WalkCodeResult {
+  ast: Program;
+  globals: Set<string>;
+  imports: Set<string>;
+  features: WalkCodeFeatures;
+  used: Set<string>;
+}
+
+export function walkCode(ast: Program): WalkCodeResult;


### PR DESCRIPTION
## Summary
- add TypeScript declaration files for all public modules
- expose typed options and helper types
- add `types` entry to package.json

## Testing
- `CI=true npm run test:node`
- `npm test` *(fails: Playwright browser download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd097a48c8330aad6f7de0ea9386d